### PR TITLE
Updated simpletest repo location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/simpletest"]
 	path = lib/simpletest
-	url = git://github.com/cbosuna/simpletest.git
+	url = git://github.com/lox/simpletest.git


### PR DESCRIPTION
1 commit in this pull request. I simply updated the repo location for simpletest from /cbosuna/ to /lox/, where there is actually a public repo.

The prevents git from choking on a submodule update, etc.
